### PR TITLE
Add hashable methods in RedisStore class

### DIFF
--- a/lib/goohub/datastore/redis_store.rb
+++ b/lib/goohub/datastore/redis_store.rb
@@ -17,6 +17,14 @@ module Goohub
       def delete(key)
         @redis.del(key)
       end
+
+      def [](key)
+        load(key)
+      end
+
+      def []=(key, value)
+        store(key, value)
+      end
     end # class RedisStore
   end # module DataStore
 end # module Goohub


### PR DESCRIPTION
RedisStore クラスに以下のメソッドを追加し，Hash ライクに扱えるようにした．
1. [](key): []演算子で key に対応する値を取得
  e.g. kvs[key] -> value
2. []=(key, value): []演算子で key に対応する位置に値を保持
  e.g. kvs[key] = value