### PR TITLE
Store calendars list to kvs by calendars command

### DIFF
--- a/lib/goohub/resource/calendar_collection.rb
+++ b/lib/goohub/resource/calendar_collection.rb
@@ -7,6 +7,10 @@ module Goohub
         end
       end
 
+      def to_json
+        @raw_resources.to_h.to_json
+      end
+
       def dump
         @raw_resources
       end


### PR DESCRIPTION
#5 に対するPRである．
### やったこと
+ 利用可能なカレンダ一覧のkvsへの保存機能の追加

### 詳細
googleカレンダー APIを用いてカレンダ一覧を取得する`calendars`コマンドに，
kvsに取得したデータを保存する機能を追加した．

具体的には，`output`オプションに対し，`kvs:host:port:name`の形式で kvs とホスト名，ポート，データベース名を指定することで任意のkvsにカレンダ一覧を保存する．
kvs に保存する際の key と value は以下の通りである．

| key | value |       
|:---|:---|
| calendars | CalendarCollectionクラスのオブジェクトをJSON形式に変換した文字列 | 

また，CalendarCollection クラス内に JSON 形式に変換するメソッド`to_json`を追加した．

以下に，`calendars`コマンドに対する`help`コマンドの出力結果を示す．
```
Usage:
  goohub calendars

Options:
  [--output=OUTPUT]  # specify output destination (stdout or redis:host:port:name)
                     # Default: stdout

List calendars
```