### PR TITLE
Make it possible to pass block to glob method in RedisStore

### DIFF
--- a/lib/goohub/datastore/redis_store.rb
+++ b/lib/goohub/datastore/redis_store.rb
@@ -22,8 +22,15 @@ module Goohub
         self.glob('*')
       end
 
-      def glob(pattern)
-        @redis.keys(pattern)
+      def glob(pattern, &block)
+        keys = @redis.keys(pattern)
+        if block_given?
+          keys.each do |key|
+            yield key
+          end
+        else
+          keys
+        end
       end
     end # class RedisStore
   end # module DataStore


### PR DESCRIPTION
RedisStore クラスの glob メソッドの引数としてブロックを渡すことができるように変更した．
この変更により以下のように使える．

``` ruby
redis = DataStore.create(:redis)
redis["2017-10-9"]  = "Holiday"
redis["2017-10-21"] = "Meeting"
redis["2017-11-01"] = "Presentation"

# ブロックを渡さない場合
p redis.glob("2017-*")
# ["2017-10-9", "2017-10-21", "2017-11-01"]

# ブロックを渡す場合
redis.glob("2017-10-*") do |key|
  puts kvs[key]
end
# Holiday
# Meeting
```
