### PR TITLE
Use docker-compose for run and development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.3.1
+
+RUN mkdir -p $HOME/.config/goohub
+
+RUN echo 'gem: --no-ri --no-rdoc' > $HOME/.gemrc
+
+ARG GOOHUB_VERSION
+ENV GOOHUB_VERSION $GOOHUB_VERSION
+
+COPY pkg/goohub-${GOOHUB_VERSION}.gem /tmp
+RUN gem install /tmp/goohub-${GOOHUB_VERSION}.gem
+
+ENTRYPOINT [ "goohub" ]
+CMD [ "help" ]

--- a/README.org
+++ b/README.org
@@ -1,11 +1,44 @@
 #+TITLE: Goohub -- CLI filter for Google calendar
 
-# * Installation
+* Installation
+Goohub requires Ruby 2.3 or newer.
+
 #   #+BEGIN_SRC sh
 
 #   #+END_SRC
 
-# * Setup
+* Setup
 #   #+BEGIN_SRC sh
 
 #   #+END_SRC
+
+* Use with Docker and docker-compose
+
+** For use
+Goohub images are in nomlab/goohub, DockerHub.
+You can build containers from it using docker-compose.yml easily.
+
+#+BEGIN_SRC sh
+$ docker-compose run --rm goohub help
+#+END_SRC
+
+** For development
+You can use Docker for development.
+
+1. Create gem pakage
+
+#+BEGIN_SRC sh
+$ bundle exec rake build
+#+END_SRC
+
+2. Build image from pakage
+
+#+BEGIN_SRC sh
+$ bundle exec rake docker:build
+#+END_SRC
+
+3. Push image to DockerHub
+
+#+BEGIN_SRC sh
+$ bundle exec rake docker:push
+#+END_SRC

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,19 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
+namespace :docker do
+  tag = "nomlab/goohub"
+
+  desc "Build Dokcer image from Dockerfile"
+  task :build do
+    version = Goohub::VERSION
+    system "docker build --build-arg GOOHUB_VERSION=#{version} -t #{tag} ."
+  end
+
+  desc "Push current Docker image to Docker Hub"
+  task :push do
+    system "docker push #{tag}"
+  end
+end
+
 task :default => :spec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  redis:
+    container_name: redis
+    image: redis
+  goohub:
+    container_name: goohub
+    image: nomlab/goohub
+    links:
+      - redis
+    volumes:
+      - $HOME/.config/goohub:/root/.config/goohub

--- a/goohub.gemspec
+++ b/goohub.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "clian", "~> 0.3.0"
-  spec.add_development_dependency "redis"
+  spec.add_runtime_dependency "redis"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
https://github.com/nomlab/camome/issues/54 に関連する PR
Goohub をコンテナで立ち上げて実行できるようにした．
また，Dockerfile から Goohub のイメージを作成し，DockerHub に push するまでの手順を簡単にするように Rakefile にタスクを追加し，README.org に手順を記載した．
https://github.com/yoshinari-nomura/glima を参考にしている．

本 PR に伴い，現バージョンの Goohub のイメージを DockerHub の nomlab/goohub に push している．
