### PR TITLE
Update README.org and Modified share command

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,7 +5,7 @@ goohubは，Google Calendarとの認証を行い，予定の取得や送信を�
 また，Google Calendar上の予定をユーザが指定したルールによって予定を書き換え，特定のメディア(Google Calendar, Slack, メール)に送信する機能をもつ．
 
 * Requirements
-+ Ruby 2.5.1 ~
++ Ruby 2.7.0 ~
 + bundler 2.1.2 ~
 
 Rubyとbundlerのインストールについては，以下を参考にすること．

--- a/README.org
+++ b/README.org
@@ -5,8 +5,8 @@ goohubは，Google Calendarとの認証を行い，予定の取得や送信を�
 また，Google Calendar上の予定をユーザが指定したルールによって予定を書き換え，特定のメディア(Google Calendar, Slack, メール)に送信する機能をもつ．
 
 * Requirements
-+ Ruby 2.1.5 ~
-+ bundler 1.15.14 ~
++ Ruby 2.5.1 ~
++ bundler 2.1.2 ~
 
 Rubyとbundlerのインストールについては，以下を参考にすること．
 + [[https://www.ruby-lang.org/ja/documentation/installation/][Rubyのインストール方法]]
@@ -19,7 +19,7 @@ $ bundler -v # check bundler version
 * Installation and Setup
 1. Clone code
  #+BEGIN_SRC sh
- $ git clone git@github.com:kjtbw/goohub.git
+ $ git clone git@github.com:nomlab/goohub.git
  #+END_SRC
 
 2. Install gems

--- a/goohub.gemspec
+++ b/goohub.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sinatra-contrib"
   spec.add_development_dependency "sinatra-cross_origin"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/goohub/command/share.rb
+++ b/lib/goohub/command/share.rb
@@ -49,8 +49,16 @@ LONGDESC
     e.summary = event.summary
     e.location = event.location
     e.description = event.description
-    e.dtstart = event.start.date_time
-    e.dtend = event.end.date_time
+    if event.start.date_time
+      e.dtstart = event.start.date_time
+    else
+      e.start = event.start.date
+    end
+    if event.start.date_time
+      e.dtend = event.end.date_time
+    else
+      e.end = event.end.date
+    end
     return e
   end
 end# class GoohubCLI

--- a/lib/goohub/expression.rb
+++ b/lib/goohub/expression.rb
@@ -268,7 +268,9 @@ module Goohub
         @sentence_items["description"] = event.description
         @sentence_items["id"] =          event.id
         @sentence_items["start_time"] =  event.dtstart
+        @sentence_items["start_date"] =  event.start
         @sentence_items["end_time"] =    event.dtend
+        @sentence_items["end_date"] =    event.end
         @sentence_items["location"] =    event.location
         @sentence_items
       end
@@ -282,17 +284,34 @@ module Goohub
       end
 
       def convert_google_event
-        event =
-          Google::Apis::CalendarV3::Event.new({
-                                                summary: @sentence_items["summary"],
-                                                start: {
-                                                  date_time: @sentence_items["start_time"],
-                                                },
-                                                end: {
-                                                  date_time: @sentence_items["end_time"],
-                                                },
-                                                location: @sentence_items["location"]
-                                              })
+        if @sentence_items["start_time"]&&@sentence_items["end_time"]
+          event =
+            Google::Apis::CalendarV3::Event.new({
+                                                  summary: @sentence_items["summary"],
+                                                  start: {
+                                                    date_time: @sentence_items["start_time"],
+                                                  },
+                                                  end: {
+                                                    date_time: @sentence_items["end_time"],
+                                                  },
+                                                  location: @sentence_items["location"]
+                                                })
+        elsif @sentence_items["start_date"]&&@sentence_items["end_date"]
+          event =
+            Google::Apis::CalendarV3::Event.new({
+                                                  summary: @sentence_items["summary"],
+                                                  start: {
+                                                    date: @sentence_items["start_date"]
+                                                  },
+                                                  end: {
+                                                    date: @sentence_items["end_date"]
+                                                  },
+                                                  location: @sentence_items["location"]
+                                                })
+        else
+          puts("Error: Event Paramater")
+          exit
+        end
         event
       end
 

--- a/lib/goohub/resource/event.rb
+++ b/lib/goohub/resource/event.rb
@@ -2,7 +2,7 @@ module Goohub
   module Resource
     class Event < Base
 
-      attr_accessor :id, :summary, :location, :description, :dtstart, :dtend
+      attr_accessor :id, :summary, :location, :description, :dtstart, :dtend, :start, :end
       def initialize(raw_resource)
         @raw_resource = raw_resource
         @id = raw_resource.id


### PR DESCRIPTION
# README.org and goohub.gemspec
+ Openssl のバージョンによっては ruby 2.1.5 がインストールできないため，Ruby と bundler のバージョンを変更
+ クローン元のリポジトリを山本さんから nomlab に変更．
+ goohub.gemspec で指定されている bundler のバージョンを削除

# share.rb, expression.rb, and resource/events.rb
+ share コマンド実行時，終日の予定を共有した場合エラーが発生する不具合を発見したため修正